### PR TITLE
fix #127 #128 #129

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 import { File } from "./src/file.ts";
 import { Dir } from "./src/dir.ts";
-import { Shape } from "./src/Shape.ts";
+import { Shape, __rest } from "./src/Shape.ts";
 import { setFs } from "./src/fs.ts";
 import { setPath } from "./src/path.ts";
 import type { Stats } from "./src/types.ts";
@@ -44,9 +44,8 @@ setFs({
       });
       if (position !== undefined)
         Deno.seekSync(file.rid, position, Deno.SeekMode.Start);
-      const toWrite = (typeof data === "string"
-        ? new TextEncoder().encode(data)
-        : data
+      const toWrite = (
+        typeof data === "string" ? new TextEncoder().encode(data) : data
       ).slice(offset, !offset || !length ? undefined : offset + length);
       file.writeSync(toWrite);
       Deno.close(file.rid);
@@ -109,4 +108,5 @@ export {
   addPlugin,
   getPluginTrack,
   getPluginTrackFormatted,
+  __rest,
 };

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -27,12 +27,10 @@ export type ShapeFilePattern = {
 
 export const name_sym = Symbol("__name");
 
-export const rest_sym = Symbol("__rest");
+export const __rest = Symbol("__rest");
 
 export type ShapeObjWithoutName = {
-  __rest?: ShapeObj | ShapeFilePattern | ShapeDir | ShapeFile;
-} & {
-  [rest_sym]?: ShapeFilePattern;
+  [__rest]?: ShapeFilePattern;
   [key: string]: ShapeObj | ShapeFile | ShapeDir;
 };
 
@@ -196,6 +194,11 @@ export class Shape<T extends ShapeObj> {
           defaultContent: fileTypeOrShapeObj.defaultContent,
         },
       };
+    }
+    if (fileTypeOrShapeObj.__rest) {
+      console.warn(
+        "please use __rest symbolic link instead of __rest, and use Shape.Pattern instead of Shape.File"
+      );
     }
     return {
       [name_sym]: name,

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -1,190 +1,64 @@
-import {
-  objAny,
-  ShapeObj,
-  createEvents,
-  isDirType,
-  isFileType,
-  fileType,
-  dirType,
-  errArr,
-  isErrArr,
-  ShapeObjWithoutName,
-  name_sym,
-  BufferType,
-} from "./types.ts";
+import { BufferType } from "./types.ts";
 import { Dir } from "./dir.ts";
 import { File } from "./file.ts";
 import { join } from "./path.ts";
 import { fsProErr } from "./fsProErr.ts";
 import { existsSync } from "./fs.ts";
 
-function createEventRegister(eventsListeners?: createEvents) {
-  return (thing: File | Dir) => {
-    if (!eventsListeners) return;
-    if (eventsListeners.onCreate) eventsListeners.onCreate(thing);
-    if (thing instanceof Dir && eventsListeners.onCreateDir)
-      eventsListeners.onCreateDir(thing);
-    if (thing instanceof File && eventsListeners.onCreateFile)
-      eventsListeners.onCreateFile(thing);
-  };
-}
+export type ShapeFile = {
+  type: 0;
+  defaultContent?: string | BufferType;
+  validator?: (this: File) => Error[] | void;
+  base: string;
+};
 
-function createShapeInst(
-  shapeObj: ShapeObj,
-  path: string,
-  eventsListeners?: createEvents
-) {
-  const parentDir = new Dir(path).create();
-  const result: objAny = {};
-  const eventRegister = createEventRegister(eventsListeners);
-  eventRegister(parentDir);
-  for (const key in shapeObj) {
-    if (key === "__rest") continue;
-    if (Object.prototype.hasOwnProperty.call(shapeObj, key)) {
-      const element = shapeObj[key];
-      if (isFileType(element)) {
-        const file = new File(parentDir.path, element.str);
-        result[key] = file;
-        if (element.dfCont) file.defaultContent = element.dfCont;
-        file.create();
-        eventRegister(file);
-      } else if (isDirType(element)) {
-        const dir = new Dir(parentDir.path, element.str).create();
-        eventRegister(dir);
-        result[key] = dir;
-      } else {
-        if (!element[name_sym])
-          throw new Error(`Use Shape.Dir() instead of raw object in ${key}`);
-        result[key] = createShapeInst(
-          element,
-          join(parentDir.path, element[name_sym] || ""),
-          eventsListeners
-        );
-      }
-    }
-  }
-  result.__dir = parentDir;
-  return result;
-}
+export type ShapeDir = {
+  type: 1;
+  name: string;
+  filePattern: ShapeFilePattern;
+};
 
-function checkStrMatchRgx(base: string, regex: string): boolean {
-  // *.ts or *.ts|*.txt or some_*.txt or some_[0-9].txt
-  const orRegex = /[^\\]\|/g;
-  const rgxs: string[] = [];
-  if (orRegex.test(regex)) {
-    let arr: RegExpExecArray | null = null;
-    while ((arr = orRegex.exec(regex)) !== null) {
-      rgxs.push(arr[0].slice(1));
-    }
-    for (const rgx of rgxs) {
-      if (!checkStrMatchRgx(base, rgx)) return false;
-    }
-    return true;
-  } else {
-    const starRegex = /(^|[^\\])\*/g;
-    // const groupRegex = /(^|[^\\])\[.*[^\\]\]/g;
-    regex = regex.replace(/\./g, "\\.");
-    // @ts-ignore
-    regex = regex.replace(starRegex, (fnd) => `${fnd === "*" ? "" : fnd[0]}.*`);
-    return RegExp(regex).test(base);
-  }
-}
+export type ShapeFilePattern = {
+  type: 2;
+  defaultContent?: string | BufferType;
+  validator?: (this: File) => Error[] | void;
+  regex: RegExp;
+};
 
-function check(
-  currentObj: ShapeObj | fileType | dirType,
-  fileOrDir: File | Dir,
-  crash: boolean,
-  isRest: boolean = false
-) {
-  if (isFileType(currentObj)) {
-    if (fileOrDir instanceof Dir) {
-      return new fsProErr("STF", fileOrDir.path);
-    } else {
-      if (isRest && !checkStrMatchRgx(fileOrDir.base, currentObj.str)) {
-        return new fsProErr("IFF", fileOrDir.path);
-      }
-      if (currentObj.validator) {
-        fileOrDir.validator = currentObj.validator;
-        fileOrDir.validate();
-      }
-    }
-    return;
-  }
-  if (isDirType(currentObj)) {
-    if (fileOrDir instanceof File) return new fsProErr("STD", fileOrDir.path);
-    const errs = errArray(crash || false);
-    fileOrDir.forEach((fileOrDir2) => {
-      if (fileOrDir2 instanceof Dir) {
-        errs.push(new fsProErr("IDF", fileOrDir2.path));
-        return;
-      }
-      if (!checkStrMatchRgx(fileOrDir2.base, currentObj.fileType.str)) {
-        errs.push(new fsProErr("IFF", fileOrDir2.path));
-        return;
-      }
-    });
-    return errs;
-  }
-  return validate(fileOrDir.path, currentObj, crash);
-}
+export const name_sym = Symbol("__name");
 
-function errArray(crash: boolean): errArr {
-  return {
-    arr: [] as fsProErr[],
-    push(err?: fsProErr | errArr) {
-      if (!err) return;
-      if (crash) throw err;
-      if (isErrArr(err)) this.arr.push(...err.arr);
-      else this.arr.push(err);
-    },
-  };
-}
+export const rest_sym = Symbol("__rest");
 
-function toFileOrDir(path: string) {
-  try {
-    return new Dir(path);
-  } catch (error) {
-    return new File(path);
-  }
-}
+export type ShapeObjWithoutName = {
+  __rest?: ShapeObj | ShapeFilePattern | ShapeDir | ShapeFile;
+} & {
+  [rest_sym]?: ShapeFilePattern;
+  [key: string]: ShapeObj | ShapeFile | ShapeDir;
+};
 
-function validate(path: string, shapeObj: ShapeObj, crash: boolean = false) {
-  const errs = errArray(crash);
-  const namesChecked: string[] = [];
-  for (const key in shapeObj) {
-    if (key === "__rest") continue;
-    if (Object.prototype.hasOwnProperty.call(shapeObj, key)) {
-      const element = shapeObj[key];
-      const name =
-        isDirType(element) || isFileType(element)
-          ? element.str
-          : element[name_sym] || "";
-      const elementPath = join(path, name);
-      if (!existsSync(elementPath)) {
-        errs.push(
-          new fsProErr(isDirType(element) ? "DDE" : "FDE", elementPath)
-        );
-        continue;
-      }
-      errs.push(check(element, toFileOrDir(elementPath), crash));
-      namesChecked.push(name);
-    }
-  }
-  const restFiles = new Dir(path).readResolve().filter((fileOrDir) => {
-    // @ts-ignore
-    if (namesChecked.includes(fileOrDir.base || fileOrDir.name)) return false;
-    return true;
-  });
-  restFiles.forEach((fileOrDir) => {
-    if (shapeObj.__rest)
-      errs.push(check(shapeObj.__rest, fileOrDir, crash, true));
-    else
-      errs.push(
-        new fsProErr(fileOrDir instanceof Dir ? "IDF" : "IFF", fileOrDir.path)
-      );
-  });
-  return errs;
-}
+export type ShapeObj = ShapeObjWithoutName & {
+  [name_sym]?: string;
+};
+
+export const isShapeFile = (obj: any): obj is ShapeFile => obj.type === 0;
+
+export const isShapeDir = (obj: any): obj is ShapeDir => obj.type === 1;
+
+export const isShapeFilePattern = (obj: any): obj is ShapeFilePattern =>
+  obj.type === 2;
+
+export type createEvents = {
+  onCreate?: (thing: File | Dir) => any;
+  onCreateFile?: (file: File) => any;
+  onCreateDir?: (thing: Dir) => any;
+};
+
+export type errArr = {
+  arr: fsProErr[];
+  push: (err?: fsProErr | errArr) => void;
+};
+
+export const isErrArr = (obj?: any): obj is errArr => obj.arr && obj.push;
 
 export class Shape<T extends ShapeObj> {
   shapeObj: ShapeObj;
@@ -222,6 +96,28 @@ export class Shape<T extends ShapeObj> {
     this.shapeObj = shape;
   }
 
+  static Pattern(
+    pattern: string | RegExp,
+    defaultContent?: string | BufferType,
+    validator?: ShapeFilePattern["validator"]
+  ): ShapeFilePattern {
+    let regex: RegExp;
+    if (typeof pattern === "string") {
+      const _ = convertPatternToRegex(pattern);
+      if (!_[1])
+        console.warn(
+          `W00: looks like the pattern you entered is a static file name please use a Shape Object instead https://github.com/AliBasicCoder/fs-pro/blob/master/NOTES.md`
+        );
+      regex = _[0];
+    } else regex = pattern;
+    return {
+      type: 2,
+      regex,
+      validator,
+      defaultContent,
+    };
+  }
+
   /**
    * use this method for adding files to your shape
    * @NOTE file regex are different than normal regex
@@ -237,15 +133,15 @@ export class Shape<T extends ShapeObj> {
    * @param validator a function used to validate the file
    */
   static File(
-    str: string,
-    dfCont?: string | BufferType,
-    validator?: fileType["validator"]
-  ): fileType {
+    base: string,
+    defaultContent?: string | BufferType,
+    validator?: ShapeFile["validator"]
+  ): ShapeFile {
     return {
-      __isFile: true,
-      dfCont,
+      type: 0,
+      defaultContent,
       validator,
-      str,
+      base,
     };
   }
 
@@ -266,36 +162,53 @@ export class Shape<T extends ShapeObj> {
    * @param str the directory name
    * @param fileTypeOrShapeObj file type of the Shape Obj
    */
-  static Dir(str: string, fileType: fileType): dirType;
-  static Dir<T extends string, K extends ShapeObjWithoutName>(
-    str: T,
+  static Dir(name: string, fileType: ShapeFile): ShapeDir;
+  static Dir<K extends ShapeObjWithoutName>(
+    name: string,
     shapeObj: K
-  ): K & { [name_sym]: T };
+  ): K & { [name_sym]: string };
   static Dir(
-    str: string,
-    fileTypeOrShapeObj: fileType | ShapeObjWithoutName
-  ): dirType | ShapeObj {
-    if (isFileType(fileTypeOrShapeObj)) {
+    name: string,
+    fileTypeOrShapeObj: ShapeFile | ShapeFilePattern | ShapeObjWithoutName
+  ): ShapeDir | ShapeObj {
+    if (isShapeFilePattern(fileTypeOrShapeObj)) {
       return {
-        __isDir: true,
-        str,
-        fileType: fileTypeOrShapeObj,
-      };
-    } else {
-      // @ts-ignore
+        type: 1,
+        name,
+        filePattern: fileTypeOrShapeObj,
+      } as ShapeDir;
+    }
+    if (isShapeFile(fileTypeOrShapeObj)) {
+      const [regex, isPattern] = convertPatternToRegex(fileTypeOrShapeObj.base);
+
+      if (isPattern)
+        console.warn(
+          `W01: looks like you passed a pattern to Shape.File use Shape.Pattern instead https://github.com/AliBasicCoder/fs-pro/blob/master/NOTES.md`
+        );
+
       return {
-        [name_sym]: str,
-        ...fileTypeOrShapeObj,
+        type: 1,
+        name,
+        filePattern: {
+          type: 2,
+          regex,
+          validator: fileTypeOrShapeObj.validator,
+          defaultContent: fileTypeOrShapeObj.defaultContent,
+        },
       };
     }
+    return {
+      [name_sym]: name,
+      ...fileTypeOrShapeObj,
+    } as ShapeObj;
   }
 
-  createShapeInst(
-    path: string,
-    eventsListeners?: createEvents
-  ): switchToShapeInstRef<T> {
-    // @ts-ignore
-    return createShapeInst(this.shapeObj, path, eventsListeners);
+  createShapeInst(path: string, eventsListeners?: createEvents) {
+    return createShapeInst(
+      this.shapeObj,
+      path,
+      eventsListeners
+    ) as switchToShapeInstRef<T>;
   }
 
   validate(path: string, crash?: boolean) {
@@ -304,9 +217,9 @@ export class Shape<T extends ShapeObj> {
 }
 
 type switchToShapeInstRef<T extends ShapeObj> = {
-  [K in keyof T]: T[K] extends fileType
+  [K in keyof T]: T[K] extends ShapeFile
     ? File
-    : T[K] extends dirType
+    : T[K] extends ShapeDir
     ? Dir
     : T[K] extends ShapeObj
     ? switchToShapeInstRef<T[K]>
@@ -314,3 +227,182 @@ type switchToShapeInstRef<T extends ShapeObj> = {
 } & {
   __dir: Dir;
 };
+
+function convertPatternToRegex(pattern: string): [RegExp, boolean] {
+  const orRegex = /[^\\]\|/g;
+  const regexs: string[] = [];
+  if (orRegex.test(pattern)) {
+    let arr: RegExpExecArray | null = null;
+    while ((arr = orRegex.exec(pattern)) !== null) {
+      regexs.push(arr[0].slice(1));
+    }
+    let result = "";
+    for (const regex of regexs) {
+      result += `(${convertPatternToRegex(regex)[0].source})|`;
+    }
+
+    return [RegExp(result.slice(0, -1)), true];
+  } else {
+    const starRegex = /(^|[^\\])\*/g;
+    let found = false;
+    pattern = pattern.replace(/\./g, "\\.");
+    pattern = pattern.replace(starRegex, (fnd) => {
+      found = true;
+      return `${fnd === "*" ? "" : fnd[0]}.*`;
+    });
+
+    return [RegExp(pattern), found];
+  }
+}
+
+function createEventRegister(eventsListeners?: createEvents) {
+  return (thing: File | Dir) => {
+    if (!eventsListeners) return;
+    if (eventsListeners.onCreate) eventsListeners.onCreate(thing);
+    if (thing instanceof Dir && eventsListeners.onCreateDir)
+      eventsListeners.onCreateDir(thing);
+    if (thing instanceof File && eventsListeners.onCreateFile)
+      eventsListeners.onCreateFile(thing);
+  };
+}
+
+function createShapeInst(
+  shapeObj: ShapeObj,
+  path: string,
+  eventsListeners?: createEvents
+) {
+  const parentDir = new Dir(path).create();
+  const result = {} as any;
+  const eventRegister = createEventRegister(eventsListeners);
+  eventRegister(parentDir);
+  for (const key in shapeObj) {
+    if (key === "__rest") continue;
+    if (Object.prototype.hasOwnProperty.call(shapeObj, key)) {
+      const element = shapeObj[key];
+      if (isShapeFile(element)) {
+        const file = new File(parentDir.path, element.base);
+        result[key] = file;
+        if (element.defaultContent)
+          file.defaultContent = element.defaultContent;
+        file.create();
+        eventRegister(file);
+      } else if (isShapeDir(element)) {
+        const dir = new Dir(parentDir.path, element.name).create();
+        eventRegister(dir);
+        result[key] = dir;
+      } else {
+        if (!element[name_sym])
+          throw new Error(`Use Shape.Dir() instead of raw object in ${key}`);
+        result[key] = createShapeInst(
+          element,
+          join(parentDir.path, element[name_sym] || ""),
+          eventsListeners
+        );
+      }
+    }
+  }
+  result.__dir = parentDir;
+  return result;
+}
+
+function errArray(crash: boolean): errArr {
+  return {
+    arr: [] as fsProErr[],
+    push(err?: fsProErr | errArr) {
+      if (!err) return;
+      if (crash) throw err;
+      if (isErrArr(err)) this.arr.push(...err.arr);
+      else this.arr.push(err);
+    },
+  };
+}
+
+function toFileOrDir(path: string) {
+  try {
+    return new Dir(path);
+  } catch (error) {
+    return new File(path);
+  }
+}
+
+function validate(path: string, shapeObj: ShapeObj, crash = false) {
+  const errs = errArray(crash);
+  const namesChecked = [] as string[];
+  for (const key in shapeObj) {
+    if (key === "__rest") continue;
+    if (!Object.prototype.hasOwnProperty.call(shapeObj, key)) continue;
+    const element = shapeObj[key];
+    let name = "";
+    if (isShapeDir(element)) name = element.name;
+    else if (isShapeFile(element)) name = element.base;
+    else name = element[name_sym] || "";
+    const elementPath = join(path, name);
+    if (!existsSync(elementPath)) {
+      errs.push(new fsProErr(isShapeDir(element) ? "DDE" : "FDE", elementPath));
+      continue;
+    }
+    errs.push(check(element, toFileOrDir(elementPath), crash));
+    namesChecked.push(name);
+  }
+  const restFiles = new Dir(path).readResolve().filter((fileOrDir) => {
+    // @ts-ignore
+    if (namesChecked.includes(fileOrDir.base || fileOrDir.name)) return false;
+    return true;
+  });
+  restFiles.forEach((fileOrDir) => {
+    if (shapeObj.__rest)
+      errs.push(check(shapeObj.__rest, fileOrDir, crash, true));
+    else
+      errs.push(
+        new fsProErr(fileOrDir instanceof Dir ? "IDF" : "IFF", fileOrDir.path)
+      );
+  });
+  return errs;
+}
+
+function check(
+  currentObj: ShapeObj | ShapeFile | ShapeDir | ShapeFilePattern,
+  fileOrDir: File | Dir,
+  crash: boolean,
+  isRest = false
+) {
+  if (isShapeFile(currentObj)) {
+    if (fileOrDir instanceof Dir) {
+      return new fsProErr("STF", fileOrDir.path);
+    }
+    if (currentObj.validator) {
+      fileOrDir.validator = currentObj.validator;
+      fileOrDir.validate();
+    }
+    return;
+  }
+  if (isShapeDir(currentObj)) {
+    if (fileOrDir instanceof File) return new fsProErr("STD", fileOrDir.path);
+    const errs = errArray(crash);
+    fileOrDir.forEach((fileOrDir2) => {
+      if (fileOrDir2 instanceof Dir) {
+        errs.push(new fsProErr("IDF", fileOrDir2.path));
+        return;
+      }
+      if (!currentObj.filePattern.regex.test(fileOrDir2.base)) {
+        errs.push(new fsProErr("IFF", fileOrDir2.path));
+        return;
+      }
+    });
+    return errs;
+  }
+  if (isShapeFilePattern(currentObj)) {
+    if (fileOrDir instanceof Dir) {
+      return new fsProErr("STF", fileOrDir.path);
+    }
+    if (!currentObj.regex.test(fileOrDir.base)) {
+      return new fsProErr("IFF", fileOrDir.path);
+    }
+    if (currentObj.validator) {
+      fileOrDir.validator = currentObj.validator;
+      fileOrDir.validate();
+    }
+    return;
+  }
+  return validate(fileOrDir.path, currentObj, crash);
+}

--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -30,7 +30,7 @@ export const name_sym = Symbol("__name");
 export const __rest = Symbol("__rest");
 
 export type ShapeObjWithoutName = {
-  [__rest]?: ShapeFilePattern;
+  [__rest]?: ShapeFilePattern | ShapeObj;
   [key: string]: ShapeObj | ShapeFile | ShapeDir;
 };
 
@@ -160,7 +160,7 @@ export class Shape<T extends ShapeObj> {
    * @param str the directory name
    * @param fileTypeOrShapeObj file type of the Shape Obj
    */
-  static Dir(name: string, fileType: ShapeFile): ShapeDir;
+  static Dir(name: string, fileType: ShapeFile | ShapeFilePattern): ShapeDir;
   static Dir<K extends ShapeObjWithoutName>(
     name: string,
     shapeObj: K
@@ -197,7 +197,7 @@ export class Shape<T extends ShapeObj> {
     }
     if (fileTypeOrShapeObj.__rest) {
       console.warn(
-        "please use __rest symbolic link instead of __rest, and use Shape.Pattern instead of Shape.File"
+        `W02: please use __rest symbol instead of "__rest" https://github.com/AliBasicCoder/fs-pro/blob/master/NOTES.md`
       );
     }
     return {
@@ -353,8 +353,10 @@ function validate(path: string, shapeObj: ShapeObj, crash = false) {
     return true;
   });
   restFiles.forEach((fileOrDir) => {
-    if (shapeObj.__rest)
-      errs.push(check(shapeObj.__rest, fileOrDir, crash, true));
+    if (shapeObj.__rest || shapeObj[__rest])
+      errs.push(
+        check(shapeObj.__rest || shapeObj[__rest], fileOrDir, crash, true)
+      );
     else
       errs.push(
         new fsProErr(fileOrDir instanceof Dir ? "IDF" : "IFF", fileOrDir.path)

--- a/src/fsProErr.ts
+++ b/src/fsProErr.ts
@@ -8,11 +8,16 @@ const msgs = {
   IDF: "Invalid Directory Found",
   IFF: "Invalid File Found",
   IFC: "Invalid File Content Found",
+  VE: "Validation Error",
 };
 
 export class fsProErr extends Error {
   [Symbol.toStringTag]: string = "fsProErr";
-  constructor(public code: keyof typeof msgs, public path: string) {
-    super(`${msgs[code]} at: ${path}`);
+  constructor(
+    public code: keyof typeof msgs,
+    public path: string,
+    public extra_message = ""
+  ) {
+    super(`${msgs[code]} at: ${path}${extra_message}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "./pluginAdder.ts";
 import { setFs } from "./fs.ts";
 import { setPath } from "./path.ts";
-import { Shape } from "./Shape.ts";
+import { Shape, __rest } from "./Shape.ts";
 import { buffer } from "./buffer.ts";
 import { watch } from "chokidar";
 import {
@@ -120,4 +120,5 @@ export {
   Shape,
   getPluginTrack,
   getPluginTrackFormatted,
+  __rest,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,9 +59,7 @@ export type fsObjType = {
 
 export type pathObjType = {
   join(...paths: string[]): string;
-  parse(
-    p: string
-  ): {
+  parse(p: string): {
     root: string;
     dir: string;
     base: string;
@@ -131,51 +129,6 @@ export interface validateOptions {
   /** called when an invalid file or directory found */
   onInvalid: (err: fsProErr, fileOrDir: File | Dir) => any;
 }
-
-// for Shape
-
-export type fileType = {
-  __isFile: true;
-  dfCont?: string | BufferType;
-  validator?: (this: File) => Error[] | void;
-  str: string;
-};
-
-export type dirType = {
-  __isDir: true;
-  str: string;
-  fileType: fileType;
-};
-
-export const name_sym = Symbol("__name");
-
-export type ShapeObj = {
-  [key: string]: ShapeObj | fileType | dirType;
-  [name_sym]?: string;
-};
-
-export type ShapeObjWithoutName = {
-  [key: string]: ShapeObj | fileType | dirType;
-} & {
-  __rest?: ShapeObj | fileType | dirType;
-};
-
-export const isFileType = (obj: any): obj is fileType => obj.__isFile === true;
-
-export const isDirType = (obj: any): obj is dirType => obj.__isDir === true;
-
-export type createEvents = {
-  onCreate?: (thing: File | Dir) => any;
-  onCreateFile?: (file: File) => any;
-  onCreateDir?: (thing: Dir) => any;
-};
-
-export type errArr = {
-  arr: fsProErr[];
-  push: (err?: fsProErr | errArr) => void;
-};
-
-export const isErrArr = (obj?: any): obj is errArr => obj.arr && obj.push;
 
 // copied from @types/node/fs.d.ts
 

--- a/test/deno/file.test.ts
+++ b/test/deno/file.test.ts
@@ -31,6 +31,18 @@ Deno.test({
   fn() {
     const file = new File(tmp_dir, randomFile()).create();
     assertEquals(existsSync(file.path), true);
+    // test defaultContent
+    const file2 = new File(tmp_dir, randomFile());
+    file2.defaultContent = "hello world";
+    file2.create();
+    assertEquals(existsSync(file2.path), true);
+    assertEquals(Deno.readTextFileSync(file2.path), "hello world");
+    // test defaultContent 2
+    const file3 = new File(tmp_dir, randomFile()).create();
+    file3.defaultContent = "hello world";
+    file3.create();
+    assertEquals(existsSync(file3.path), true);
+    assertEquals(Deno.readTextFileSync(file3.path), "hello world");
   },
 });
 

--- a/test/deno/shape.test.ts
+++ b/test/deno/shape.test.ts
@@ -124,7 +124,11 @@ Deno.test({
     const dir2 = Dir.tmpDir();
     const sub_dir2 = dir2.createDir("something2");
     sub_dir2.createFile("hi.txt");
+    sub_dir2.createFile("hi.text").write("hello world");
     sub_dir2.createFile("hi");
-    assertEquals(shape3.validate(dir2.path).arr.length, 2);
+    assertEquals(
+      shape3.validate(dir2.path).arr.map((err) => err.code),
+      ["IFF", "VE"]
+    );
   },
 });

--- a/test/deno/shape.test.ts
+++ b/test/deno/shape.test.ts
@@ -126,9 +126,6 @@ Deno.test({
     sub_dir2.createFile("hi.txt");
     sub_dir2.createFile("hi.text").write("hello world");
     sub_dir2.createFile("hi");
-    assertEquals(
-      shape3.validate(dir2.path).arr.map((err) => err.code),
-      ["IFF", "VE"]
-    );
+    assertEquals(shape3.validate(dir2.path).arr.length, 2);
   },
 });

--- a/test/deno/shape.test.ts
+++ b/test/deno/shape.test.ts
@@ -1,7 +1,7 @@
 import { join } from "https://deno.land/std@0.131.0/path/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.131.0/testing/asserts.ts";
 import { existsSync, statSync } from "https://deno.land/std@0.131.0/node/fs.ts";
-import { Shape, Dir, File } from "../../mod.ts";
+import { Shape, Dir, File, __rest } from "../../mod.ts";
 
 /** Et stands for Existence and Type */
 function ET(...paths: string[]) {
@@ -22,55 +22,74 @@ const shape = new Shape({
   __rest: Shape.File("rest[0-9]{3}.txt|*.any"),
 });
 
+const shape2 = new Shape({
+  some_file: Shape.File("some_file.txt"),
+  some_dir: Shape.Dir("some_dir", {
+    some_dir_2: Shape.Dir("some_dir_2", Shape.Pattern("*.txt")),
+    some_file_2: Shape.File("some_file_2"),
+    [__rest]: Shape.Pattern("*.txt"),
+  }),
+  some_dir_3: Shape.Dir("some_dir_3", Shape.File("*.txt")),
+  [__rest]: Shape.Pattern("rest[0-9]{3}.txt|*.any"),
+});
+
 Deno.test({
   name: "Shape.createShapeInst()",
   fn() {
-    const target_dir = Dir.tmpDir();
-    const shapeInstRef = shape.createShapeInst(target_dir.path);
+    [shape, shape2].forEach((s) => {
+      const target_dir = Dir.tmpDir();
+      const shapeInstRef = s.createShapeInst(target_dir.path);
 
-    assertEquals(ET(target_dir.path, "some_file.txt"), [true, true]);
-    assertEquals(ET(target_dir.path, "some_dir"), [true, false]);
-    assertEquals(ET(target_dir.path, "some_dir/some_dir_2"), [true, false]);
-    assertEquals(ET(target_dir.path, "some_dir_3"), [true, false]);
-    assertEquals(ET(target_dir.path, "some_dir/__rest"), [false, null]);
-    assertEquals(ET(target_dir.path, "__rest"), [false, null]);
+      assertEquals(ET(target_dir.path, "some_file.txt"), [true, true]);
+      assertEquals(ET(target_dir.path, "some_dir"), [true, false]);
+      assertEquals(ET(target_dir.path, "some_dir/some_dir_2"), [true, false]);
+      assertEquals(ET(target_dir.path, "some_dir_3"), [true, false]);
+      assertEquals(ET(target_dir.path, "some_dir/__rest"), [false, null]);
+      assertEquals(ET(target_dir.path, "__rest"), [false, null]);
 
-    assertEquals(shapeInstRef.__dir instanceof Dir, true);
-    assertEquals(shapeInstRef.some_file instanceof File, true);
-    assertEquals(shapeInstRef.some_dir_3 instanceof Dir, true);
-    assertEquals(shapeInstRef.some_dir.__dir instanceof Dir, true);
-    assertEquals(shapeInstRef.some_dir.some_dir_2 instanceof Dir, true);
-    assertEquals(shapeInstRef.some_dir.some_file_2 instanceof File, true);
+      assertEquals(shapeInstRef.__dir instanceof Dir, true);
+      assertEquals(shapeInstRef.some_file instanceof File, true);
+      assertEquals(shapeInstRef.some_dir_3 instanceof Dir, true);
+      assertEquals(shapeInstRef.some_dir.__dir instanceof Dir, true);
+      assertEquals(shapeInstRef.some_dir.some_dir_2 instanceof Dir, true);
+      assertEquals(shapeInstRef.some_dir.some_file_2 instanceof File, true);
+    });
   },
 });
 
 Deno.test({
   name: "Shape.validate() empty folder",
   fn() {
-    const target_dir = Dir.tmpDir();
-    assertEquals(shape.validate(target_dir.path).arr.length, 3);
+    [shape, shape2].forEach((s) => {
+      const target_dir = Dir.tmpDir();
+      assertEquals(s.validate(target_dir.path).arr.length, 3);
+    });
   },
 });
 
 Deno.test({
   name: "Shape.validate() correct folder",
   fn() {
-    const target_dir = Dir.tmpDir();
-    shape.createShapeInst(target_dir.path);
-    assertEquals(shape.validate(target_dir.path).arr.length, 0);
+    [shape, shape2].forEach((s) => {
+      const target_dir = Dir.tmpDir();
+      s.createShapeInst(target_dir.path);
+      assertEquals(s.validate(target_dir.path).arr.length, 0);
+    });
   },
 });
 
 Deno.test({
   name: "Shape.validate() __rest",
   fn() {
-    const target_dir = Dir.tmpDir();
-    shape.createShapeInst(target_dir.path);
+    [shape, shape2].forEach((s) => {
+      const target_dir = Dir.tmpDir();
+      s.createShapeInst(target_dir.path);
 
-    target_dir.createFile("rest100.txt");
-    target_dir.createFile("foo12021bar.any");
-    target_dir.getDir("some_dir").createFile("some_thing.txt");
+      target_dir.createFile("rest100.txt");
+      target_dir.createFile("foo12021bar.any");
+      target_dir.getDir("some_dir").createFile("some_thing.txt");
 
-    assertEquals(shape.validate(target_dir.path).arr.length, 0);
+      assertEquals(s.validate(target_dir.path).arr.length, 0);
+    });
   },
 });


### PR DESCRIPTION
this PR should fix issues #127 #128 #129 and add some features

it turns out there are some bugs that should be fixed now also

Bug 1: Shape.File("*.something|*.somethingelse") didn't work this entire time
combining two or more patterns didn't work but one pattern worked fine

Bug 2: if File.validator produce any error fs-pro would have just ignored it

Issue 1: onCreate, onCreateFile, onCreateDir were not tested at all

Issue 2: Combine multiple were not tested

Issue 3: pattern testing was not tested at all