### PR TITLE
fix #136

### DIFF
--- a/src/Shape.ts
+++ b/src/Shape.ts
@@ -38,6 +38,14 @@ export type ShapeObj = ShapeObjWithoutName & {
   [name_sym]?: string;
 };
 
+export type WithRest<T extends ShapeObj> = T & OldRest;
+
+export type ShapeObjRest = ShapeObjWithoutName & OldRest;
+
+type OldRest = {
+  __rest: ShapeObj | ShapeFile | ShapeDir;
+};
+
 export const isShapeFile = (obj: any): obj is ShapeFile => obj.type === 0;
 
 export const isShapeDir = (obj: any): obj is ShapeDir => obj.type === 1;
@@ -59,8 +67,13 @@ export type errArr = {
 export const isErrArr = (obj?: any): obj is errArr => obj.arr && obj.push;
 
 export class Shape<T extends ShapeObj> {
-  shapeObj: ShapeObj;
+  shapeObj: T;
 
+  /**
+   * @deprecated since v3.8.0
+   * please use __rest symbol instead
+   */
+  constructor(shape: WithRest<T>);
   /**
    * the Shape class is a class that helps you create folder with a certain shape (hierarchy)
    * or test if a folder have a certain shape (hierarchy)
@@ -143,6 +156,7 @@ export class Shape<T extends ShapeObj> {
    * ```
    * @param shape
    */
+  constructor(shape: T);
   constructor(shape: T) {
     this.shapeObj = shape;
   }
@@ -207,7 +221,20 @@ export class Shape<T extends ShapeObj> {
    * @param name name of the folder
    * @param fileTypeOrShapeObj file type of the Shape Obj
    */
-  static Dir(name: string, fileType: ShapeFile | ShapeFilePattern): ShapeDir;
+  static Dir(name: string, fileType: ShapeFilePattern): ShapeDir;
+  /**
+   * @deprecated since v3.8.0
+   * please use Shape.Pattern instead of Shape.File
+   */
+  static Dir(name: string, fileType: ShapeFile): ShapeDir;
+  /**
+   * @deprecated since v3.8.0
+   * please use __rest symbol instead
+   */
+  static Dir<K extends ShapeObjRest>(
+    name: string,
+    shapeObj: K
+  ): K & { [name_sym]: string };
   static Dir<K extends ShapeObjWithoutName>(
     name: string,
     shapeObj: K

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -29,7 +29,7 @@ const shape2 = new Shape({
     some_file_2: Shape.File("some_file_2"),
     [__rest]: Shape.Pattern("*.txt"),
   }),
-  some_dir_3: Shape.Dir("some_dir_3", Shape.File("*.txt")),
+  some_dir_3: Shape.Dir("some_dir_3", Shape.Pattern("*.txt")),
   [__rest]: Shape.Pattern("rest[0-9]{3}.txt|*.any"),
 });
 

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -129,3 +129,47 @@ test({
     assertEquals(shape3.validate(dir2.path).arr.length, 2);
   },
 });
+
+function customEquals(
+  actual: [string, string][],
+  expected: [string, string][]
+) {
+  if (actual.length !== expected.length) {
+    // using assertEquals cause it will print diffs better
+    assertEquals(actual, expected);
+    return;
+  }
+  let found = 0;
+  for (let i = 0; i < actual.length; i++) {
+    if (actual[i][0] === expected[i][0] && actual[i][1] === expected[i][1])
+      found++;
+  }
+  if (found !== expected.length) {
+    console.log(actual, expected);
+    assertEquals(found, expected.length);
+  }
+}
+
+test({
+  name: "Shape.validate() __rest 3",
+  fn() {
+    [shape, shape2].forEach((s, i) => {
+      const dir = Dir.tmpDir();
+      const file1 = dir.createFile("rest123.txt.some");
+      const file2 = dir.createFile("something.any.some");
+      const sub_dir = dir.createDir("some_dir_3");
+      const file3 = sub_dir.createFile("hi.txt.some");
+
+      const errs = s
+        .validate(dir.path)
+        .arr.map((err) => [err.code, err.path]) as [string, string][];
+      customEquals(errs, [
+        ["FDE", join(dir.path, "some_file.txt")],
+        ["DDE", join(dir.path, "some_dir")],
+        ["IFF", file3.path],
+        ["IFF", file2.path],
+        ["IFF", file1.path],
+      ]);
+    });
+  },
+});

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -140,9 +140,11 @@ function customEquals(
     return;
   }
   let found = 0;
-  for (let i = 0; i < actual.length; i++) {
-    if (actual[i][0] === expected[i][0] && actual[i][1] === expected[i][1])
-      found++;
+  for (let i = 0; i < expected.length; i++) {
+    for (let y = 0; y < expected.length; y++) {
+      if (expected[i][0] === actual[y][0] && expected[i][1] === actual[y][1])
+        found++;
+    }
   }
   if (found !== expected.length) {
     console.log(actual, expected);


### PR DESCRIPTION
this PR should fix bug #136 as will as

1. deprecate some old api

2. fix Bug: it looks like since v3.8.0 __rest string key with Shape.File didn't work

example

```
test_dir
--- hi
--- hi.nottxt
--- hi.txt.some
```

```js
const shape = new Shape({
  __rest: Shape.File("*.txt")
});

// runs normally
// should return two errors
shape.validate("./test_dir");
```


